### PR TITLE
Add plugin dependencies

### DIFF
--- a/cookiecutter_plugin.json
+++ b/cookiecutter_plugin.json
@@ -4,6 +4,10 @@
     "__plugin_options_class": "{{ cookiecutter.plugin_name | replace(' ', '') | replace('-', '') | replace('_', '') }}Options",
     "plugin_type": ["Exploiter", "Credentials_Collector", "Payload"],
     "plugin_options": true,
+
+    "_monkeyagentpluginapi_version": "0.11.0",
+    "_monkeytypes_version": "0.7.0",
+
     "__prompts__": {
         "plugin_type": "Select the type of plugin",
         "plugin_options": "Will your plugin require configuration in order to run?"

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -71,6 +71,10 @@ black = "{{ cookiecutter._black_version }}"
 dlint = "{{ cookiecutter._dlint_version }}"
 flake8 = "{{ cookiecutter._flake8_version }}"
 isort = "{{ cookiecutter._isort_version }}"
+{%- if cookiecutter.__project_type=="agent_plugin" %}
+monkey-agentpluginapi = "{{ cookiecutter._monkeyagentpluginapi_version }}"
+monkey-types = "{{ cookiecutter._monkeytypes_version }}"
+{%- endif %}
 mypy = "{{ cookiecutter._mypy_version }}"
 pudb = "^2022.1.2"
 pynvim = "^0.4.3"


### PR DESCRIPTION
All of the plugin types require the same two dependencies: `monkey-agentpluginapi` and `monkey-types`.
I updated the plugin cookiecutter template to add those dependencies to `pyproject.toml`