### PR TITLE
Add agent-plugin-builder as an agent_plugin dev dependency

### DIFF
--- a/cookiecutter_plugin.json
+++ b/cookiecutter_plugin.json
@@ -5,6 +5,7 @@
     "plugin_type": ["Exploiter", "Credentials_Collector", "Payload"],
     "plugin_options": true,
 
+    "_agentpluginbuilder_version": "0.1.0",
     "_monkeyagentpluginapi_version": "0.11.0",
     "_monkeytypes_version": "0.7.0",
 

--- a/cookiecutter_plugin.json
+++ b/cookiecutter_plugin.json
@@ -5,7 +5,7 @@
     "plugin_type": ["Exploiter", "Credentials_Collector", "Payload"],
     "plugin_options": true,
 
-    "_agentpluginbuilder_version": "0.1.0",
+    "_agentpluginbuilder_version": "0.3.0",
     "_monkeyagentpluginapi_version": "0.11.0",
     "_monkeytypes_version": "0.7.0",
 

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -67,6 +67,9 @@ include = ["CHANGELOG.md", "README.md"]
 python = "^{{ cookiecutter.python_major_version }}.{{ cookiecutter.python_minor_version }}"
 
 [tool.poetry.group.dev.dependencies]
+{%- if cookiecutter.__project_type=="agent_plugin" %}
+agent-plugin-builder = "{{ cookiecutter._agentpluginbuilder_version }}"
+{%- endif %}
 black = "{{ cookiecutter._black_version }}"
 dlint = "{{ cookiecutter._dlint_version }}"
 flake8 = "{{ cookiecutter._flake8_version }}"


### PR DESCRIPTION
Tested with a plugin (zerologon exploiter).
After setting up the project, the build command required was:
```shell
$ build_agent_plugin . -s zerologon_exploiter
```