### PR TITLE
Use tool.poetry.group.dev.dependencies

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -66,7 +66,7 @@ include = ["CHANGELOG.md", "README.md"]
 [tool.poetry.dependencies]
 python = "^{{ cookiecutter.python_major_version }}.{{ cookiecutter.python_minor_version }}"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = "{{ cookiecutter._black_version }}"
 dlint = "{{ cookiecutter._dlint_version }}"
 flake8 = "{{ cookiecutter._flake8_version }}"


### PR DESCRIPTION
Poetry 1.2.0+ uses the `dev` group for dev dependencies. For backward compatibility, anything declared under tool.poetry.dev-dependencies is added to the `dev` group. However, dev-dependencies is deprecated, so we should switch to using the `dev` group.